### PR TITLE
Add the recycle of TypedArray and fix the dircetion of up and down

### DIFF
--- a/app/src/main/java/com/jscheng/flipapplication/view/NewFlipLayout.java
+++ b/app/src/main/java/com/jscheng/flipapplication/view/NewFlipLayout.java
@@ -33,13 +33,11 @@ public class NewFlipLayout extends FrameLayout implements OnSwipeListener{
     private boolean isFlip;
     private AtomicBoolean isFliping;
     public NewFlipLayout(Context context) {
-        super(context);
-        init(context);
+        this(context,null);
     }
 
     public NewFlipLayout(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        init(context,attrs);
+        this(context, attrs, 0);
     }
 
     public NewFlipLayout(Context context, AttributeSet attrs, int defStyleAttr) {
@@ -75,13 +73,16 @@ public class NewFlipLayout extends FrameLayout implements OnSwipeListener{
 
     private void init(Context context,AttributeSet attrs){
         init(context);
-        TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.flip);
-        int direction = ta.getInt(R.styleable.flip_direction,0);
-        switch (direction){
-            case 0: this.direction = Direction.Default;break;
-            case 1: this.direction = Direction.Vertical;break;
-            case 2: this.direction = Direction.Horizontal;break;
-            default:this.direction = Direction.Default;break;
+        if (attrs != null) {
+            TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.flip);
+            int direction = ta.getInt(R.styleable.flip_direction,0);
+            switch (direction){
+                case 0: this.direction = Direction.Default;break;
+                case 1: this.direction = Direction.Vertical;break;
+                case 2: this.direction = Direction.Horizontal;break;
+                default:this.direction = Direction.Default;break;
+            }
+            ta.recycle();
         }
     }
 

--- a/app/src/main/java/com/jscheng/flipapplication/view/OnSwipeTouchListener.java
+++ b/app/src/main/java/com/jscheng/flipapplication/view/OnSwipeTouchListener.java
@@ -69,16 +69,16 @@ public class OnSwipeTouchListener implements OnTouchListener {
           }
           result = true;
         } else if (Math.abs(diffY) > SWIPE_THRESHOLD
-            && Math.abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
+                && Math.abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
           if (diffY > 0) {
-            for (OnSwipeListener swipeListener : swipeListeners) {
-              swipeListener.onSwipeDown();
-              Log.d("Gesture", "SwipeDown");
-            }
-          } else {
             for (OnSwipeListener swipeListener : swipeListeners) {
               swipeListener.onSwipeUp();
               Log.d("Gesture", "SwipeUp");
+            }
+          } else {
+            for (OnSwipeListener swipeListener : swipeListeners) {
+              swipeListener.onSwipeDown();
+              Log.d("Gesture", "SwipeDown");
             }
           }
         }


### PR DESCRIPTION
Firstly, The constructors of NewFlipLayout can be used the constructors which has the most arguments.
Then the typedArray need to be recycled, it can avoid the memory leak.
Finally, the gesture of touchdown and touchup is reverse.